### PR TITLE
Move pages to root

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,0 @@
-/about 			/pages/about
-/software		/pages/software
-/hardware		/pages/hardware

--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,6 @@
 # Activate and configure extensions
 # https://middlemanapp.com/advanced/configuration/#configuring-extensions
 
-activate :directory_indexes
 activate :autoprefixer do |prefix|
   prefix.browsers = "last 2 versions"
 end

--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -1,0 +1,5 @@
+---
+title: About
+---
+
+<h1>About</h1>

--- a/source/hardware.html.erb
+++ b/source/hardware.html.erb
@@ -1,0 +1,5 @@
+---
+title: Hardware
+---
+
+<h1>Hardware</h1>

--- a/source/pages/about.html.erb
+++ b/source/pages/about.html.erb
@@ -1,3 +1,0 @@
----
-title: About
----

--- a/source/pages/hardware.html.erb
+++ b/source/pages/hardware.html.erb
@@ -1,3 +1,0 @@
----
-title: Hardware
----

--- a/source/pages/software.html.erb
+++ b/source/pages/software.html.erb
@@ -1,3 +1,0 @@
----
-title: Software
----

--- a/source/partials/_menu.html.erb
+++ b/source/partials/_menu.html.erb
@@ -1,11 +1,17 @@
 <div id="menu">
 	<span class="title">Harrison Broadbent</span>
 	<ul>
-		<% Dir.entries('source/pages')[2..-1].sort.each do |page| %>
-			<li>
-				<% page_name_components = page.split(".") %>
-				<%= link_to page_name_components[0].capitalize, "/pages/#{page_name_components[0,2].join('.')}" %>
-			</li>
+		<% Dir.entries('source').sort.each do |page| %>
+			<%# Regex to filter out "." and ".." directories found by Dir.entries %>
+			<% if not page =~ /^[.]+/ %>
+				<%# Filter out folders and index file (as its empty) %>
+				<% if page.include? "html" and not page.include? "index" %>
+					<li>
+						<% page_name_components = page.split(".") %>
+						<%= link_to page_name_components[0].to_s.capitalize, "#{page_name_components[0,2].join('.')}" %>
+					</li>
+				<% end%>
+			<% end %>
 		<% end %>
 	</ul>
 </div>

--- a/source/software.html.erb
+++ b/source/software.html.erb
@@ -1,0 +1,5 @@
+---
+title: Software
+---
+
+<h1>Software</h1>


### PR DESCRIPTION
Move pages from pages/ to root 
Rewrite menu partial logic to look in root and filter out folders and index
remove directory_indexes extension as Netlify offers the same functionality
re-add in page headings as I forgot to git pull to update my local master branch 