### PR TITLE
Add notes to site

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -17,7 +17,7 @@ page '/*.json', layout: false
 page '/*.txt', layout: false
 
 # With alternative layout
-# page '/path/to/file.html', layout: 'other_layout'
+ page '/notes/*', layout: 'notes_layout'
 
 # Proxy pages
 # https://middlemanapp.com/advanced/dynamic-pages/

--- a/source/layouts/notes_layout.erb
+++ b/source/layouts/notes_layout.erb
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+
+    <%# only include tag in production %>
+    <% if app.build? %>
+      <%= partial 'partials/tracking_snippet' %>
+    <% end %>
+
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- Use the title from a page's frontmatter if it has one -->
+    <title><%= current_page.data.title + " · Harrison Broadbent" %></title>
+    <%= stylesheet_link_tag "site" %>
+    <%= javascript_include_tag "site" %>
+  </head>
+  <body>
+
+    <%= partial 'partials/left'%>
+
+    <div id="content-container">
+      <div id="content">
+
+	  	<h1><%= current_page.data.title %></h1>
+		<span class="byline"><%= current_page.data.date %></span>
+        <%= yield %>
+		
+      </div>
+    </div>
+
+    <%= partial 'partials/menu'%>
+
+  </body>
+</html>

--- a/source/layouts/notes_layout.erb
+++ b/source/layouts/notes_layout.erb
@@ -24,8 +24,8 @@
       <div id="content">
 
 	  	<h1><%= current_page.data.title %></h1>
-		<span class="byline"><%= current_page.data.date %></span>
-        <%= yield %>
+		  <span class="byline"><%= current_page.data.date %></span>
+      <%= yield %>
 		
       </div>
     </div>

--- a/source/notes/index.html.md.erb
+++ b/source/notes/index.html.md.erb
@@ -11,6 +11,6 @@ Some notes (and many questions) on the books I have read.
 	.sort_by { |child| child.data.date }
 	.reverse
 	.each do |resource|%>
-		<li><%= link_to(resource.data.title, resource.path) %></li>
+		<li><%= link_to(resource.data.title, resource.path, :relative => true) %></li>
 	<% end %>
 </ul>

--- a/source/notes/index.html.md.erb
+++ b/source/notes/index.html.md.erb
@@ -11,6 +11,8 @@ Some notes (and many questions) on the books I have read.
 	.sort_by { |child| child.data.date }
 	.reverse
 	.each do |resource|%>
-		<li><%= link_to(resource.data.title, resource.path, :relative => true) %></li>
+		<li>
+			<%= link_to resource.data.title, resource %>
+		</li>
 	<% end %>
 </ul>

--- a/source/notes/index.html.md.erb
+++ b/source/notes/index.html.md.erb
@@ -1,0 +1,16 @@
+---
+title: Notes
+---
+
+Some notes (and many questions) on the books I have read. 
+
+[//]: # (sort notes by reverse date order so the newest are listed first)
+<ul>
+	<% current_resource
+	.children
+	.sort_by { |child| child.data.date }
+	.reverse
+	.each do |resource|%>
+		<li><%= link_to(resource.data.title, resource.path) %></li>
+	<% end %>
+</ul>

--- a/source/notes/moonwalking_with_einstein.html.md
+++ b/source/notes/moonwalking_with_einstein.html.md
@@ -1,0 +1,6 @@
+---
+title: Moonwalking with Einstein, Joshua Foer
+date: 2020-03-06
+---
+
+Some thoughts on this book.

--- a/source/notes/the_handmaids_tale.html.md
+++ b/source/notes/the_handmaids_tale.html.md
@@ -1,0 +1,6 @@
+---
+title: The Handmaids Tale, Margaret Atwood
+date: 2020-03-07
+---
+
+My body vs. your body

--- a/source/partials/_menu.html.erb
+++ b/source/partials/_menu.html.erb
@@ -8,7 +8,7 @@
 				<% if page.include? "html" and not page.include? "index" %>
 					<li>
 						<% page_name_components = page.split(".") %>
-						<%= link_to page_name_components[0].to_s.capitalize, "#{page_name_components[0,2].join('.')}" %>
+						<%= link_to page_name_components[0].to_s.capitalize, "/#{page_name_components[0,2].join('.')}" %>
 					</li>
 				<% end%>
 			<% end %>

--- a/source/reading.html.md
+++ b/source/reading.html.md
@@ -4,16 +4,20 @@ title: Reading
 
 # Reading
 
-I read quite a lot. Here are some of my favorites -
+I read quite a lot. Sometimes when I read, I also take [notes](notes).
+
+Here is an (non-exhaustive) list of books I have read, with **standouts** highlighted -
 
 ### Non-fiction
 
-- [Educated, Tara Westover](https://amzn.to/38t9rPR)
-- [Steve Jobs, Walter Isaacson](https://amzn.to/39u4o2H)
-- [The Power of Habit, Charles Duhigg](https://amzn.to/3cvWBDL)
+- [**Educated, Tara Westover**](https://amzn.to/38t9rPR)
+- [**Steve Jobs, Walter Isaacson**](https://amzn.to/39u4o2H)
+- [**The Power of Habit, Charles Duhigg**](https://amzn.to/3cvWBDL)
+- [Moonwalking with Einstein, Joshua Foer](https://amzn.to/2PWcjOF) \| [notes](notes/moonwalking_with_einstein.html)
 
 ### Fiction
 
 - [Eragon, Christopher Paolini](https://amzn.to/2TKU7sk)
-- [13 1/2 Lives of Captain Bluebear, Walter Moers](https://amzn.to/3aCs1Xj)
 - [The Remains of the Day, Kazuo Ishiguro](https://amzn.to/2x9rCwQ)
+- [**13 1/2 Lives of Captain Bluebear, Walter Moers**](https://amzn.to/3aCs1Xj)
+- [The Handmaids Tale, Margaret Atwood](https://amzn.to/2Qa506j) \| [notes](notes/the_handmaids_tale.html)

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -25,6 +25,10 @@ a {
   }
 }
 
+ul {
+  list-style: none;
+}
+
 #left {
   min-width: 0;
   width: 12vw;
@@ -39,11 +43,13 @@ a {
 
 #menu {
   text-align: right;
-  ul {
-    list-style: none;
-  }
 }
 
 .profile-img {
   max-width: 130px;
+}
+
+.byline {
+  font-size: 11px;
+  color: #666;
 }


### PR DESCRIPTION
- Use custom layout for notes section (notes_layout.erb), specify this
in config.rb
- Add a /notes section, for notes on books I read
- Add notes/index to display all notes in order of newest->oldest
- Add stubs for 2 notes files
- Modified menu partial to use absoloute routes
	- menu was directing to notes/about etc. when reading a book
note
- modified reading page to link to notes/index, and add links to notes
for the handmaids tale and moonwalking with einstein
- modify css to remove decorations for all <ul> elements on the site